### PR TITLE
dcd-server now terminates itself! (kinda)

### DIFF
--- a/DKit.py
+++ b/DKit.py
@@ -158,6 +158,10 @@ class DCD(sublime_plugin.EventListener):
         if not (server_process is None) and server_process.poll() is None:
             server_process.terminate()
 
+    def on_window_command(self, window, command_name, args):
+        if command_name == ("exit" or "close_window"):
+            Popen(client_path + " --shutdown", shell=True)
+
     def on_query_completions(self, view, prefix, locations):
         if view.scope_name(locations[0]).strip() != 'source.d':
             return

--- a/DKit.py
+++ b/DKit.py
@@ -159,7 +159,7 @@ class DCD(sublime_plugin.EventListener):
             server_process.terminate()
 
     def on_window_command(self, window, command_name, args):
-        if command_name == ("exit" or "close_window"):
+        if command_name in ("exit", "close_window"):
             Popen(client_path + " --shutdown", shell=True)
 
     def on_query_completions(self, view, prefix, locations):

--- a/DKit.py
+++ b/DKit.py
@@ -159,7 +159,7 @@ class DCD(sublime_plugin.EventListener):
             server_process.terminate()
 
     def on_window_command(self, window, command_name, args):
-        if command_name in ("exit", "close_window"):
+        if command_name == "exit":
             Popen(client_path + " --shutdown", shell=True)
 
     def on_query_completions(self, view, prefix, locations):


### PR DESCRIPTION
The problem with sublime is that it is impossible to know if the
editor has exited without shelling out to an external watch program.
The API has some misleading function names that might be misconstrued
as promising, but in practice they turn out to be useless.

By digging around in the sublime documentation for window commands, I
was able to find "exit", and "close_window". The former is executed by
File->Exit, and the latter by File->Close Window (or ctrl+shift+w).
As of yet, I have not seen anything that gets called by a regular
close (i.e. clicking the big red "X"), but this is a promising
temporary solution for those who hate having memory taken up by the
server.

Also, I haven't done extensive testing, but "exit", and "close_window"
seem to be the only commands that are executed at the complete
shutdown of the application. "close_file" might be worth checking out,
but the documentation for it is nonexistent

Perhaps resolves #1?