### PR TITLE
Expand env variables before call dcd-client/dcd-server.

### DIFF
--- a/DKit.py
+++ b/DKit.py
@@ -132,8 +132,8 @@ def start_server():
     global server_path
     server_path = os.path.join(dcd_path, 'dcd-server' + ('.exe' if sys.platform == 'win32' else ''))
     client_path = os.path.join(dcd_path, 'dcd-client' + ('.exe' if sys.platform == 'win32' else ''))
-    server_path = sublime.expand_variables(server_path, sublime.active_window().extract_variables());
-    client_path = sublime.expand_variables(client_path, sublime.active_window().extract_variables());
+    server_path = sublime.expand_variables(server_path, sublime.active_window().extract_variables())
+    client_path = sublime.expand_variables(client_path, sublime.active_window().extract_variables())
 
     if not os.path.exists(server_path):
         sublime.error_message('DCD server doesn\'t exist in the path specified:\n' + server_path + '\n\nSetup the path in DCD package settings and then restart sublime to get things working.')

--- a/DKit.py
+++ b/DKit.py
@@ -132,6 +132,8 @@ def start_server():
     global server_path
     server_path = os.path.join(dcd_path, 'dcd-server' + ('.exe' if sys.platform == 'win32' else ''))
     client_path = os.path.join(dcd_path, 'dcd-client' + ('.exe' if sys.platform == 'win32' else ''))
+    server_path = sublime.expand_variables(server_path, sublime.active_window().extract_variables());
+    client_path = sublime.expand_variables(client_path, sublime.active_window().extract_variables());
 
     if not os.path.exists(server_path):
         sublime.error_message('DCD server doesn\'t exist in the path specified:\n' + server_path + '\n\nSetup the path in DCD package settings and then restart sublime to get things working.')


### PR DESCRIPTION
I use portable version of ST3. So my `DKit.sublime-settings` looks like:
```json
{
  "dcd_path": "${packages}\\..\\..\\..\\DCD",
  "dcd_port": 9166,
  "include_paths": [
    "${packages}\\..\\..\\..\\dmd2\\src\\phobos",
    "${packages}\\..\\..\\..\\dmd2\\src\\druntime\\import"
  ]
}
```
And i got "not found" error.