### PR TITLE
Allow autocompletion inside of block statements

### DIFF
--- a/DKit.py
+++ b/DKit.py
@@ -165,7 +165,7 @@ class DCD(sublime_plugin.EventListener):
             Popen(client_path + " --shutdown", shell=True)
 
     def on_query_completions(self, view, prefix, locations):
-        if view.scope_name(locations[0]).strip() != 'source.d':
+        if not view.scope_name(locations[0]).startswith('source.d'):
             return
 
         global server_process


### PR DESCRIPTION
DKit does not work with build 3103 of Sublime Text. It seems that a side effect of the syntax highlighting fixes is that the string returned by view.scope_name has changed.

Checking for "starts with" instead of equality seems to fix the issue.