### PR TITLE
Properly interpret double slashes in documentation

### DIFF
--- a/DKit.py
+++ b/DKit.py
@@ -354,7 +354,7 @@ class DcdGotoDefinitionCommand(sublime_plugin.TextCommand):
 
 class DcdShowDocumentationCommand(sublime_plugin.TextCommand):
     _REGEX = re.compile(r'(?<!\\)\\('
-                        '(?P<code>[\\\'"abfnrtv])|'
+                        '(?P<code>[\\\\\\\'"abfnrtv])|'
                         '(?P<oct>[0-7]{1,3})|'
                         'x(?P<hex>[0-9a-fA-F]{1,2})|'
                         'u(?P<uni>[0-9a-fA-F]{4})|'


### PR DESCRIPTION
`\\` escapes were previously not included in the regex (despite having a mapping).
Older versions of DCR returned `\n` both for new lines and literal `\` and `n` characters, which caused DKit to misbehave. For example, the description of `writeln` looked like this:
```
Equivalent to `write(args, '
')`.  Calling `writeln` without
arguments is valid and just prints a newline to the standard
output.
```

This was fixed in some version of DCR (it now returns `\\n` when it's a literal `\n` and still just a `\n` when it's a line break), but without this change, DKit shows the description of `writeln` as:

```
Equivalent to `write(args, '\\n')`.  Calling `writeln` without
arguments is valid and just prints a newline to the standard
output.
```

With this tiny fix, it now shows up as:

```
Equivalent to `write(args, '\n')`.  Calling `writeln` without
arguments is valid and just prints a newline to the standard
output.
```