### PR TITLE
Improved 'Update Import Paths', various other fixes

### DIFF
--- a/DKit.sublime-commands
+++ b/DKit.sublime-commands
@@ -4,6 +4,10 @@
     "command": "dcd_start_server"
   },
   {
+    "caption": "DKit: Kill DCD Autocompletion Server",
+    "command": "dcd_kill_server"
+  },
+  {
     "caption": "DKit: Update Import Paths",
     "command": "dcd_update_include_paths"
   },


### PR DESCRIPTION
* Update Import Paths now also runs Update Project first
* Restart DCD Autocompletion Server now actually restarts the server - tries to kill it first.
* Added the port number to some things that lacked it, like the 'Restart DCD Autocompletion Server'
  check for whether the server is already running (and that check can be overriden using the new
  'force' argument)
* New 'Kill DCD Autocomplete Server' command to shut down dcd-server

This PR also changes some paths so that they point to the open folder instead of weird undocumented settings or the current file's parent directory, so that you can open a DUB project and it'll still compile properly even if you run DUB from inside a D file inside directories.