### PR TITLE
Fix build paths

### DIFF
--- a/D.sublime-build
+++ b/D.sublime-build
@@ -7,31 +7,32 @@
   [
     {
       "name": "Run",
-      "cmd": ["rdmd", "-g", "-debug", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["rdmd", "-g", "-debug", "$file_name"]
     },
     {
       "name": "dub",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub"]
     },
     {
       "name": "dub (single file)",
-      "working_dir": "$project_path",
-      "cmd": ["dub", "--single", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["dub", "--single", "$file_name"]
     },
     {
       "name": "dub build",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub", "build"]
     },
     {
       "name": "dub build (single file)",
-      "working_dir": "$project_path",
-      "cmd": ["dub", "build", "--single", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["dub", "build", "--single", "$file_name"]
     },
     {
       "name": "dub test",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub", "test"]
     }
   ]


### PR DESCRIPTION
Build commands which are supposed to run with the whole project will now start at the root of the current open directory in Sublime, which allows you to put your source files e.g. in a `source` sub directory and still have `Build with: dub` compile the project.