### PR TITLE
Various fixes to project handling and docs

### DIFF
--- a/D.sublime-build
+++ b/D.sublime-build
@@ -7,31 +7,32 @@
   [
     {
       "name": "Run",
-      "cmd": ["rdmd", "-g", "-debug", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["rdmd", "-g", "-debug", "$file_name"]
     },
     {
       "name": "dub",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub"]
     },
     {
       "name": "dub (single file)",
-      "working_dir": "$project_path",
-      "cmd": ["dub", "--single", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["dub", "--single", "$file_name"]
     },
     {
       "name": "dub build",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub", "build"]
     },
     {
       "name": "dub build (single file)",
-      "working_dir": "$project_path",
-      "cmd": ["dub", "build", "--single", "$file"]
+      "working_dir": "$file_path",
+      "cmd": ["dub", "build", "--single", "$file_name"]
     },
     {
       "name": "dub test",
-      "working_dir": "$project_path",
+      "working_dir": "$folder",
       "cmd": ["dub", "test"]
     }
   ]

--- a/DKit.py
+++ b/DKit.py
@@ -117,27 +117,55 @@ def on_load(path=None, window=None, encoded_row_col=True, begin_edit=False):
 
     return wrapper
 
-def start_server():
-    global server_process
+def get_active_project_path():
+    import os
+    window = sublime.active_window()
+    folders = window.folders()
+    if len(folders) == 1:
+        return folders[0]
+    else:
+        active_view = window.active_view()
+        active_file_name = active_view.file_name() if active_view else None
+        if not active_file_name:
+            return folders[0] if len(folders) else os.path.expanduser("~")
+        for folder in folders:
+            if active_file_name.startswith(folder):
+                return folder
+        return os.path.dirname(active_file_name)
+
+def ensure_paths_are_set():
+    global server_path
     global client_path
-
-    out = call(client_path + " -q", shell=True, stdout=PIPE)
-    if out == 0:
-        print("Already running!")
-        return
-
     global plugin_settings
+
     plugin_settings = sublime.load_settings('DKit.sublime-settings')
 
-    global server_port
     server_port = read_settings('dcd_port', 9166)
     dcd_path = read_settings('dcd_path', '')
 
-    global server_path
     server_path = os.path.join(dcd_path, 'dcd-server' + ('.exe' if sys.platform == 'win32' else ''))
     client_path = os.path.join(dcd_path, 'dcd-client' + ('.exe' if sys.platform == 'win32' else ''))
     server_path = sublime.expand_variables(server_path, sublime.active_window().extract_variables())
     client_path = sublime.expand_variables(client_path, sublime.active_window().extract_variables())
+
+def kill_server():
+    global client_path
+    ensure_paths_are_set()
+    call(client_path + " -p" + str(server_port) + " --shutdown", shell=True, stdout=PIPE)
+    print(client_path + " -p" + str(server_port) + " --shutdown")
+
+def start_server(view, force = False):
+    global server_process
+    global client_path
+    global server_port
+    global server_path
+
+    out = call(client_path + " -p" + str(server_port) + " -q", shell=True, stdout=PIPE)
+    if out == 0 and not force:
+        print("Already running!")
+        return
+
+    ensure_paths_are_set()
 
     if not os.path.exists(server_path):
         sublime.error_message('DCD server doesn\'t exist in the path specified:\n' + server_path + '\n\nSetup the path in DCD package settings and then restart sublime to get things working.')
@@ -146,6 +174,8 @@ def start_server():
     if not os.path.exists(client_path):
         sublime.error_message('DCD client doesn\'t exist in the path specified:\n' + client_path + '\n\nSetup the path in DCD package settings and then restart sublime to get things working.')
         return False
+
+    dub = Popen(get_shell_args(['dub', 'describe', '--import-paths']), stdin=PIPE, stdout=PIPE, shell=True, cwd=get_active_project_path())
 
     include_paths = read_all_settings('include_paths')
     include_paths = ['-I"' + p + '"' for p in include_paths]
@@ -158,8 +188,8 @@ def start_server():
     server_process = Popen(get_shell_args(args), shell=True)
     return True
 
-def update_project(view, package_file):
-    dub = Popen(get_shell_args(['dub', 'describe']), stdin=PIPE, stdout=PIPE, shell=True, cwd=os.path.dirname(package_file))
+def update_project(view, package_folder):
+    dub = Popen(get_shell_args(['dub', 'describe']), stdin=PIPE, stdout=PIPE, shell=True, cwd=get_active_project_path())
     description = dub.communicate()
     description = description[0].decode('utf-8')
 
@@ -228,7 +258,7 @@ class DCD(sublime_plugin.EventListener):
 
         global server_process
         if server_process is None:
-            start_server()
+            start_server(view)
 
         position = locations[0]
         position = position - len(prefix)
@@ -300,14 +330,21 @@ class DCD(sublime_plugin.EventListener):
             text = line
         return visible_name, text
 
-class DcdStartServerCommand(sublime_plugin.ApplicationCommand):
-    def run(self):
-        start_server()
+class DcdStartServerCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        kill_server()
+        start_server(self.view, force = True)
+
+class DcdKillServerCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        kill_server()
 
 class DcdUpdateIncludePathsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
+        update_project(self.view, get_active_project_path())
+
         global client_path
-        Popen(get_shell_args(['"%s"' % client_path, '--clearCache']), shell=True).wait()
+        Popen(get_shell_args(['"%s"' % client_path, '-p' + str(server_port), '--clearCache']), shell=True).wait()
 
         include_paths = set()
         for path in self.view.settings().get('include_paths', []):
@@ -321,6 +358,7 @@ class DcdUpdateIncludePathsCommand(sublime_plugin.TextCommand):
             args.extend(['-I' + p for p in include_paths])
 
             Popen(get_shell_args(args), shell=True).wait()
+            print(get_shell_args(args))
 
 class DcdGotoDefinitionCommand(sublime_plugin.TextCommand):
     def run(self, edit):
@@ -330,7 +368,7 @@ class DcdGotoDefinitionCommand(sublime_plugin.TextCommand):
             return
 
         pos = self.view.sel()[0].a
-        args = ['"%s"' % client_path, '--symbolLocation', '-c', str(pos), '-p', str(server_port)]
+        args = ['"%s"' % client_path, '--symbolLocation', '-p' + str(server_port), '-c', str(pos)]
 
         client = Popen(get_shell_args(args), stdin=PIPE, stdout=PIPE, shell=True)
         contents = self.view.substr(sublime.Region(0, self.view.size()))
@@ -354,7 +392,7 @@ class DcdGotoDefinitionCommand(sublime_plugin.TextCommand):
 
 class DcdShowDocumentationCommand(sublime_plugin.TextCommand):
     _REGEX = re.compile(r'(?<!\\)\\('
-                        '(?P<code>[\\\'"abfnrtv])|'
+                        '(?P<code>[\\\\\\\'"abfnrtv])|'
                         '(?P<oct>[0-7]{1,3})|'
                         'x(?P<hex>[0-9a-fA-F]{1,2})|'
                         'u(?P<uni>[0-9a-fA-F]{4})|'
@@ -464,5 +502,4 @@ class DubUpdateProjectCommand(sublime_plugin.TextCommand):
             sublime.error_message("The active project does not specify the path to the DUB package file.")
             return
 
-        package_file = normalize_from_project_dir(package_file)
-        update_project(self.view, package_file)
+        update_project(self.view, get_active_project_path())

--- a/DKit.sublime-commands
+++ b/DKit.sublime-commands
@@ -4,6 +4,10 @@
     "command": "dcd_start_server"
   },
   {
+    "caption": "DKit: Kill DCD Autocompletion Server",
+    "command": "dcd_kill_server"
+  },
+  {
     "caption": "DKit: Update Import Paths",
     "command": "dcd_update_include_paths"
   },


### PR DESCRIPTION
This is a merge of #47, #46 and #45. If you're going to merge these, please merge this PR instead, as #46 and #47 contain merge conflicts which this PR has solved.

* Properly interpret double slashes in documentation

* Fix build paths
  Build commands which are supposed to run with the whole project will now
  start at the root of the current open directory in Sublime, which allows
  you to put your source files e.g. in a `source` sub directory and still
  have `Build with: dub` compile the project.

* Improved 'Update Import Paths', various other fixes
  * Update Import Paths now also runs Update Project first
  * Restart DCD Autocompletion Server now actually restarts the server - tries to kill it first.
  * Added the port number to some things that lacked it, like the 'Restart DCD Autocompletion Server'
    check for whether the server is already running (and that check can be overriden using the new
    'force' argument)
  * New 'Kill DCD Autocomplete Server' command to shut down dcd-server